### PR TITLE
Feat/redefinir senha

### DIFF
--- a/controllers/autenticacaoController.js
+++ b/controllers/autenticacaoController.js
@@ -32,12 +32,13 @@ export const recuperarSenha = async (req, res) => {
             return res.status(404).json({ mensagem: 'Usuário não encontrado' });
         }
 
-        const payload = { uid: usuario.uid };
+        // Use o campo correto do usuário Firestore
+        const payload = { uid: usuario.id }; // Aqui, 'id' é o uid do Auth
         const token = tokenService.gerarToken(payload);
 
         await usuarioController.salvarTokenRedefinicao(usuario.id, token);
 
-        const linkRedefinicao = `${process.env.FRONTEND_URL}/redefinir-senha?token=${token}`;
+        const linkRedefinicao = `${process.env.FRONTEND_URL}/autenticacao/redefinir-senha/${token}`;
 
         await emailService.enviarEmailRedefinicao(email, linkRedefinicao);
 
@@ -65,8 +66,7 @@ export const redefinirSenha = async (req, res) => {
         const { novaSenha } = req.body;
 
         const decoded = tokenService.verificarToken(token);
-        const uid = decoded.uid || decoded.userId; // use o campo correto conforme seu payload
-
+        const uid = decoded.uid; // ou decoded.userId, conforme o payload
         if (!uid) {
             return res.status(400).json({ erro: 'UID inválido para redefinição de senha.' });
         }

--- a/services/emailService.js
+++ b/services/emailService.js
@@ -19,6 +19,8 @@ export const enviarEmailRedefinicao = async (email, link) => {
     html: `
       <p>Você solicitou a redefinição de senha. Clique no link abaixo:</p>
       <a href="${link}">Redefinir Senha</a>
+      <p>Se preferir, copie e cole o link na barra de endereço:</p>
+      <p>${link}</p>
       <p>Se não foi você, ignore este e-mail.</p>
     `
   };


### PR DESCRIPTION
This pull request includes updates to the password recovery and reset functionality, as well as improvements to the email content for password reset notifications. The changes ensure correct usage of user identifiers, enhance the password reset link structure, and provide clearer instructions in the email.

### Updates to password recovery functionality:
* [`controllers/autenticacaoController.js`](diffhunk://#diff-5a39a686dfa297acbfeaf59bc63084d69f6063761082ccaa90e1a06d258cb158L35-R41): Corrected the user identifier field in the payload from `usuario.uid` to `usuario.id`, ensuring compatibility with Firestore's user schema. Updated the password reset link structure to use `/autenticacao/redefinir-senha/{token}` for improved routing.

### Updates to password reset functionality:
* [`controllers/autenticacaoController.js`](diffhunk://#diff-5a39a686dfa297acbfeaf59bc63084d69f6063761082ccaa90e1a06d258cb158L68-R69): Simplified the extraction of the `uid` from the decoded token, ensuring alignment with the payload structure. Removed redundant fallback logic.

### Improvements to email content:
* [`services/emailService.js`](diffhunk://#diff-d9bb524b311e7b8b8ffa51ddd51edd0ca55c91be1a750b55412f7443f03c29c2R22-R23): Enhanced the email template by adding instructions to copy and paste the password reset link, making the process more user-friendly.